### PR TITLE
Remove the broken discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to NQ-RARBG
 
-Would you like to contribute to NQ-RARBG? Join our Discord: <https://discord.gg/rQx6tZhP6W> or [file an issue](https://github.com/Not-Quite-RARBG/main/issues) or [pull request](https://github.com/Not-Quite-RARBG/main/compare).
+Would you like to contribute to NQ-RARBG? [File an issue](https://github.com/Not-Quite-RARBG/main/issues) or [pull request](https://github.com/Not-Quite-RARBG/main/compare).

--- a/README.md
+++ b/README.md
@@ -19,5 +19,3 @@ After achieving this goal, the website will open registrations, so users can upl
 ## Why
   
 The whole community really misses the OG RARBG as it was the GOAT of torrent sites. As a community we want to revive RARBG.
-  
-Join the Discord server: https://discord.gg/rQx6tZhP6W


### PR DESCRIPTION
Remove the broken discord link, to stop people creating issues about the expired discord link